### PR TITLE
Implement Pydantic schemas and CRUD routes for movie API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,5 @@ ignore = E203, E266, W503, ANN002, ANN003, ANN101, ANN102, ANN401, N807, N818, V
 max-line-length = 119
 max-complexity = 18
 select = B,C,E,F,W,T4,B9,ANN,Q0,N8,VNE
-exclude = .venv
+exclude = .venv, src/database/migrations
 extend-exclude = src/tests/*

--- a/src/crud/movies.py
+++ b/src/crud/movies.py
@@ -1,0 +1,85 @@
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from database import MovieModel
+from database.models import ActorModel, CountryModel, GenreModel, LanguageModel
+from schemas.movies import MovieCreateRequestSchema, MovieUpdateRequestSchema
+
+
+def get_movies_with_pagination(offset: int, per_page: int, db: Session) -> tuple[list[MovieModel], int]:
+    """Retrieves paginated movies from database by ID descending."""
+    movies = db.query(MovieModel).order_by(MovieModel.id.desc()).offset(offset).limit(per_page).all()
+    movies_count = db.query(MovieModel).count()
+
+    return movies, movies_count
+
+
+def create_movie(movie_data: MovieCreateRequestSchema, db: Session) -> MovieModel:
+    """Creates new movie record with all related entities."""
+    country = db.query(CountryModel).filter(CountryModel.code == movie_data.country).first()
+
+    if not country:
+        country = CountryModel(code=movie_data.country)
+        db.add(country)
+        db.flush()
+
+    genres = [
+        db.query(GenreModel).filter(GenreModel.name == name).first() or GenreModel(name=name)
+        for name in movie_data.genres
+    ]
+    actors = [
+        db.query(ActorModel).filter(ActorModel.name == name).first() or ActorModel(name=name)
+        for name in movie_data.actors
+    ]
+    languages = [
+        db.query(LanguageModel).filter(LanguageModel.name == name).first() or LanguageModel(name=name)
+        for name in movie_data.languages
+    ]
+
+    new_movie = MovieModel(
+        **movie_data.model_dump(exclude={"country", "genres", "actors", "languages"}),
+        country=country,
+        genres=genres,
+        actors=actors,
+        languages=languages,
+    )
+
+    db.add(new_movie)
+    db.commit()
+    db.refresh(new_movie)
+
+    return new_movie
+
+
+def get_movie_by_id(movie_id: int, db: Session) -> MovieModel | None:
+    """Retrieves single movie by ID."""
+    return db.query(MovieModel).filter(MovieModel.id == movie_id).first()
+
+
+def get_movie_by_name_and_date(name: str, date: date, db: Session) -> MovieModel | None:
+    """
+    Checks if movie with given name and date exists.
+
+    Used for duplicate checking during creation.
+    """
+    return db.query(MovieModel).filter(MovieModel.name == name, MovieModel.date == date).first()
+
+
+def delete_movie(movie: MovieModel, db: Session) -> None:
+    """Deletes movie and all its relationships."""
+    db.delete(movie)
+    db.commit()
+
+
+def update_movie(movie: MovieModel, movie_data: MovieUpdateRequestSchema, db: Session) -> MovieModel:
+    """Updates movie with partial data."""
+    update_data = movie_data.model_dump(exclude_unset=True)
+
+    for field, value in update_data.items():
+        setattr(movie, field, value)
+
+    db.commit()
+    db.refresh(movie)
+
+    return movie

--- a/src/database/populate.py
+++ b/src/database/populate.py
@@ -6,8 +6,15 @@ from tqdm import tqdm
 
 from config import get_settings
 from database import MovieModel, get_db_contextmanager
-from database.models import CountryModel, GenreModel, ActorModel, MoviesGenresModel, ActorsMoviesModel, LanguageModel, \
-    MoviesLanguagesModel
+from database.models import (
+    CountryModel,
+    GenreModel,
+    ActorModel,
+    MoviesGenresModel,
+    ActorsMoviesModel,
+    LanguageModel,
+    MoviesLanguagesModel,
+)
 
 
 class CSVDatabaseSeeder:
@@ -138,6 +145,7 @@ class CSVDatabaseSeeder:
         except Exception as e:
             print(f"Unexpected error: {e}")
             raise
+
 
 def main():
     settings = get_settings()

--- a/src/routes/movies.py
+++ b/src/routes/movies.py
@@ -1,12 +1,107 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, joinedload
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
 
+from crud import movies as movies_crud
 from database import get_db
-from database.models import MovieModel, CountryModel, GenreModel, ActorModel, LanguageModel
+from schemas.movies import (
+    MovieCreateRequestSchema,
+    MovieCreateResponseSchema,
+    MovieDetailResponseSchema,
+    MovieListReadResponseSchema,
+    MovieListResponseSchema,
+    MovieUpdateRequestSchema,
+)
 
 
 router = APIRouter()
 
 
-# Write your code here
+@router.get("/movies/", response_model=MovieListResponseSchema)
+def get_movies(
+    page: int = Query(1, ge=1, description="Page number"),
+    per_page: int = Query(10, ge=1, le=20, description="Number of movies per page"),
+    db: Session = Depends(get_db),
+) -> MovieListResponseSchema:
+    """Get paginated list of movies."""
+    offset = (page - 1) * per_page
+    movies_query, total_movies = movies_crud.get_movies_with_pagination(offset, per_page, db)
+    total_pages = (total_movies + per_page - 1) // per_page
+
+    if page > total_pages or not total_movies:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No movies found.")
+
+    base_url = "/theater/movies/"
+    prev_page = f"{base_url}?page={page - 1}&per_page={per_page}" if page > 1 else None
+    next_page = f"{base_url}?page={page + 1}&per_page={per_page}" if page < total_pages else None
+
+    return MovieListResponseSchema(
+        movies=[MovieListReadResponseSchema.model_validate(movie) for movie in movies_query],
+        prev_page=prev_page,
+        next_page=next_page,
+        total_pages=total_pages,
+        total_items=total_movies,
+    )
+
+
+@router.post("/movies/", response_model=MovieCreateResponseSchema, status_code=status.HTTP_201_CREATED)
+def create_movie(
+    movie_data: MovieCreateRequestSchema,
+    db: Session = Depends(get_db),
+) -> MovieCreateResponseSchema:
+    """
+    Creates a new movie with all relationships.
+    If related entities don't exist, they will be created.
+    """
+    existing_movie = movies_crud.get_movie_by_name_and_date(movie_data.name, movie_data.date, db)
+
+    if existing_movie:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A movie with the name '{movie_data.name}' and release date '{movie_data.date}' already exists.",
+        )
+
+    try:
+        new_movie = movies_crud.create_movie(movie_data, db)
+        return MovieCreateResponseSchema.model_validate(new_movie)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid input data.")
+
+
+@router.get("/movies/{movie_id}", response_model=MovieDetailResponseSchema)
+def get_movie(movie_id: int, db: Session = Depends(get_db)) -> MovieDetailResponseSchema:
+    """Get detailed movie information by ID."""
+    movie = movies_crud.get_movie_by_id(movie_id, db)
+
+    if not movie:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Movie with the given ID was not found.")
+
+    return MovieDetailResponseSchema.model_validate(movie)
+
+
+@router.delete("/movies/{movie_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_movie(movie_id: int, db: Session = Depends(get_db)) -> None:
+    """Delete movie by ID."""
+    movie_to_delete = movies_crud.get_movie_by_id(movie_id, db)
+
+    if not movie_to_delete:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Movie with the given ID was not found.")
+
+    movies_crud.delete_movie(movie_to_delete, db)
+
+
+@router.patch("/movies/{movie_id}")
+def update_movie(movie_id: int, movie_data: MovieUpdateRequestSchema, db: Session = Depends(get_db)) -> dict[str, str]:
+    """
+    Partially updates movie information. Only provided fields will be updated.
+    Relationships cannot be updated.
+    """
+    movie_to_update = movies_crud.get_movie_by_id(movie_id, db)
+
+    if not movie_to_update:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Movie with the given ID was not found.")
+
+    try:
+        movies_crud.update_movie(movie_to_update, movie_data, db)
+        return {"detail": "Movie updated successfully."}
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid input data.")

--- a/src/schemas/movies.py
+++ b/src/schemas/movies.py
@@ -1,4 +1,5 @@
-from datetime import date, timedelta
+import datetime
+from datetime import timedelta
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -47,7 +48,7 @@ class MovieListReadResponseSchema(BaseModel):
 
     id: int
     name: str
-    date: date
+    date: datetime.date
     score: float
     overview: str
 
@@ -70,13 +71,13 @@ class MovieCreateRequestSchema(BaseModel):
     """Schema for movie creation request."""
 
     name: str = Field(max_length=255)
-    date: date = Field(le=date.today() + timedelta(days=365))
+    date: datetime.date = Field(le=datetime.date.today() + timedelta(days=365))
     score: float = Field(ge=0, le=100)
     overview: str
     status: MovieStatusEnum
     budget: float = Field(ge=0)
     revenue: float = Field(ge=0)
-    country: str = Field(pattern="^[A-Z]{3}$", description="ISO 3166-1 alpha-3 code")
+    country: str = Field(max_length=3, description="ISO 3166-1 alpha-3 code")
     genres: list[str]
     actors: list[str]
     languages: list[str]
@@ -87,7 +88,7 @@ class MovieCreateResponseSchema(BaseModel):
 
     id: int
     name: str
-    date: date
+    date: datetime.date
     score: float
     overview: str
     status: MovieStatusEnum
@@ -106,7 +107,7 @@ class MovieDetailResponseSchema(BaseModel):
 
     id: int
     name: str
-    date: date
+    date: datetime.date
     score: float
     overview: str
     status: MovieStatusEnum
@@ -123,10 +124,10 @@ class MovieDetailResponseSchema(BaseModel):
 class MovieUpdateRequestSchema(BaseModel):
     """Schema for movie update request."""
 
-    name: str | None = Field(max_length=255)
-    date: date | None = Field(le=date.today() + timedelta(days=365))
-    score: float | None = Field(ge=0, le=100)
-    overview: str | None
-    status: MovieStatusEnum | None
-    budget: float | None = Field(ge=0)
-    revenue: float | None = Field(ge=0)
+    name: str | None = Field(None, max_length=255)
+    date: datetime.date | None = Field(None, le=datetime.date.today() + timedelta(days=365))
+    score: float | None = Field(None, ge=0, le=100)
+    overview: str | None = None
+    status: MovieStatusEnum | None = None
+    budget: float | None = Field(None, ge=0)
+    revenue: float | None = Field(None, ge=0)

--- a/src/schemas/movies.py
+++ b/src/schemas/movies.py
@@ -1,1 +1,132 @@
-# Write your code here
+from datetime import date, timedelta
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from database.models import MovieStatusEnum
+
+
+class GenreResponseSchema(BaseModel):
+    """Schema for genre response."""
+
+    id: int
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ActorResponseSchema(BaseModel):
+    """Schema for actor response."""
+
+    id: int
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CountryResponseSchema(BaseModel):
+    """Schema for country response."""
+
+    id: int
+    code: str
+    name: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LanguageResponseSchema(BaseModel):
+    """Schema for language response."""
+
+    id: int
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MovieListReadResponseSchema(BaseModel):
+    """Schema for movie list item response."""
+
+    id: int
+    name: str
+    date: date
+    score: float
+    overview: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MovieListResponseSchema(BaseModel):
+    """Schema for paginated movie list response."""
+
+    movies: list[MovieListReadResponseSchema]
+    prev_page: str | None
+    next_page: str | None
+    total_pages: int
+    total_items: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MovieCreateRequestSchema(BaseModel):
+    """Schema for movie creation request."""
+
+    name: str = Field(max_length=255)
+    date: date = Field(le=date.today() + timedelta(days=365))
+    score: float = Field(ge=0, le=100)
+    overview: str
+    status: MovieStatusEnum
+    budget: float = Field(ge=0)
+    revenue: float = Field(ge=0)
+    country: str = Field(pattern="^[A-Z]{3}$", description="ISO 3166-1 alpha-3 code")
+    genres: list[str]
+    actors: list[str]
+    languages: list[str]
+
+
+class MovieCreateResponseSchema(BaseModel):
+    """Schema for movie creation response."""
+
+    id: int
+    name: str
+    date: date
+    score: float
+    overview: str
+    status: MovieStatusEnum
+    budget: float
+    revenue: float
+    country: CountryResponseSchema
+    genres: list[GenreResponseSchema]
+    actors: list[ActorResponseSchema]
+    languages: list[LanguageResponseSchema]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MovieDetailResponseSchema(BaseModel):
+    """Schema for detailed movie response."""
+
+    id: int
+    name: str
+    date: date
+    score: float
+    overview: str
+    status: MovieStatusEnum
+    budget: float
+    revenue: float
+    country: CountryResponseSchema
+    genres: list[GenreResponseSchema]
+    actors: list[ActorResponseSchema]
+    languages: list[LanguageResponseSchema]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MovieUpdateRequestSchema(BaseModel):
+    """Schema for movie update request."""
+
+    name: str | None = Field(max_length=255)
+    date: date | None = Field(le=date.today() + timedelta(days=365))
+    score: float | None = Field(ge=0, le=100)
+    overview: str | None
+    status: MovieStatusEnum | None
+    budget: float | None = Field(ge=0)
+    revenue: float | None = Field(ge=0)


### PR DESCRIPTION
- Add base response schemas for related entities
- Add request/response schemas for movie CRUD operations
- Implement field validations and constraints
- Add pagination support in list response schema
- Add all CRUD operations and routes for managing movies
- Update .flake8 configuration to exclude migration files
- Refactor populate.py file