### PR TITLE
Implement full movie CRUD with pagination and relation handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - PYTHONPATH=/usr/src/fastapi
       - WATCHFILES_FORCE_POLLING=true
     ports:
-      - "8000:8000"
+      - "8002:8000"
     depends_on:
       db:
         condition: service_healthy

--- a/src/crud/movie_crud.py
+++ b/src/crud/movie_crud.py
@@ -1,10 +1,17 @@
-from sqlalchemy import select
+from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import CountryModel
 
 
 async def get_or_create_country(name_or_code: str, db: AsyncSession):
-    result = await db.execute(select(CountryModel).where(CountryModel.code == name_or_code))
+    result = await db.execute(
+        select(CountryModel).where(
+            or_(
+                CountryModel.code == name_or_code,
+                CountryModel.name == name_or_code
+             )
+        )
+    )
     country = result.scalar_one_or_none()
     if not country:
         country = CountryModel(code=name_or_code)

--- a/src/crud/movie_crud.py
+++ b/src/crud/movie_crud.py
@@ -1,0 +1,27 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from database.models import CountryModel
+
+
+async def get_or_create_country(name_or_code: str, db: AsyncSession):
+    result = await db.execute(select(CountryModel).where(CountryModel.code == name_or_code))
+    country = result.scalar_one_or_none()
+    if not country:
+        country = CountryModel(code=name_or_code)
+        db.add(country)
+        await db.commit()
+        await db.refresh(country)
+    return country
+
+
+async def get_or_create_many(model, names: list[str], db: AsyncSession):
+    instances = []
+    for name in names:
+        result = await db.execute(select(model).where(model.name == name))
+        obj = result.scalar_one_or_none()
+        if not obj:
+            obj = model(name=name)
+            db.add(obj)
+            await db.flush()
+        instances.append(obj)
+    return instances

--- a/src/routes/movies.py
+++ b/src/routes/movies.py
@@ -32,12 +32,13 @@ async def get_movies(page: int = Query(1, ge=1),
     )
     result = await db.execute(stmt)
     movies = result.scalars().all()
+    short_movies = [MovieShortSchema.model_validate(movie) for movie in movies]
     base_url = "/theater/movies/"
     prev_url = f"{base_url}?page={page - 1}&per_page={per_page}" if page > 1 else None
     next_url = f"{base_url}?page={page + 1}&per_page={per_page}" if page * per_page < total else None
 
     return PaginatedMoviesResponse(
-        movies=movies,
+        movies=short_movies,
         prev_page=prev_url,
         next_page=next_url,
         total_pages=(total + per_page - 1) // per_page,
@@ -129,7 +130,7 @@ async def update_movie(movie_id: int, movie_update: MovieUpdate, db: AsyncSessio
     try:
         await db.commit()
         await db.refresh(movie)
-        return {"detail": "Movie updated successfully."}
+        return movie
 
     except Exception as e:
         print(f"Error occurred: {e}")

--- a/src/routes/movies.py
+++ b/src/routes/movies.py
@@ -1,13 +1,148 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import select, func
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
-
-from database import get_db, MovieModel
-from database.models import CountryModel, GenreModel, ActorModel, LanguageModel
-
+from sqlalchemy.orm import selectinload
+from crud.movie_crud import get_or_create_country, get_or_create_many
+from database import get_db
+from schemas.movies import MoviesListResponse, MovieBase, MovieRead, MovieCreate, MovieUpdate, PaginatedMoviesResponse
+from database.models import GenreModel, ActorModel, LanguageModel, MovieModel
 
 router = APIRouter()
 
-# Write your code here
+
+@router.get("/movies/", response_model=PaginatedMoviesResponse)
+async def get_movies(page: int = Query(1, ge=1),
+                     per_page: int = Query(10, ge=1, le=50),
+                     db: AsyncSession = Depends(get_db)):
+    total_stmt = select(func.count(MovieModel.id))
+    total = (await db.execute(total_stmt)).scalar_one()
+    if total == 0 or (page - 1) * per_page >= total:
+        raise HTTPException(status_code=404, detail="No movies found.")
+    stmt = (
+        select(MovieModel)
+        .options(
+            selectinload(MovieModel.country),
+            selectinload(MovieModel.genres),
+            selectinload(MovieModel.actors),
+            selectinload(MovieModel.languages),
+        )
+        .order_by(MovieModel.id.desc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+    )
+    result = await db.execute(stmt)
+    movies = result.scalars().all()
+    base_url = "/theater/movies/"
+    prev_url = f"{base_url}?page={page - 1}&per_page={per_page}" if page > 1 else None
+    next_url = f"{base_url}?page={page + 1}&per_page={per_page}" if page * per_page < total else None
+
+    return PaginatedMoviesResponse(
+        movies=movies,
+        prev_page=prev_url,
+        next_page=next_url,
+        total_pages=(total + per_page - 1) // per_page,
+        total_items=total
+    )
+
+
+@router.get("/movies/{movie_id}/", response_model=MovieRead)
+async def get_movie(movie_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(MovieModel)
+        .options(selectinload(MovieModel.genres),
+                 selectinload(MovieModel.actors),
+                 selectinload(MovieModel.languages),
+                 selectinload(MovieModel.country))
+        .where(MovieModel.id == movie_id))
+    movie = result.unique().scalar_one_or_none()
+    if not movie:
+        raise HTTPException(status_code=404,
+                            detail="Movie with the given ID was not found."
+                            )
+    return movie
+
+
+@router.post("/movies/", response_model=MovieRead, status_code=201)
+async def add_movie(movie_create: MovieCreate, db: AsyncSession = Depends(get_db)):
+    # Duplicate check
+    result = await db.execute(select(MovieModel).where(
+        MovieModel.name == movie_create.name,
+        MovieModel.date == movie_create.date
+    ))
+    if result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=409,
+            detail=f"A movie with the name '{movie_create.name}' and release date '{movie_create.date}' already exists.")
+    country = await get_or_create_country(movie_create.country, db)
+    genres = await get_or_create_many(GenreModel, movie_create.genres, db)
+    actors = await get_or_create_many(ActorModel, movie_create.actors, db)
+    languages = await get_or_create_many(LanguageModel, movie_create.languages, db)
+    new_movie = MovieModel(
+        name=movie_create.name,
+        date=movie_create.date,
+        score=movie_create.score,
+        overview=movie_create.overview,
+        status=movie_create.status,
+        budget=movie_create.budget,
+        revenue=movie_create.revenue,
+        country_id=country.id,
+    )
+    new_movie.genres = genres
+    new_movie.actors = actors
+    new_movie.languages = languages
+    db.add(new_movie)
+    await db.commit()
+    await db.refresh(new_movie)
+    result = await db.execute(
+        select(MovieModel)
+        .options(
+            selectinload(MovieModel.country),
+            selectinload(MovieModel.genres),
+            selectinload(MovieModel.actors),
+            selectinload(MovieModel.languages),
+        )
+        .where(MovieModel.id == new_movie.id)
+    )
+    movie_with_relations = result.scalar_one()
+
+    return movie_with_relations
+
+
+@router.patch("/movies/{movie_id}/", response_model=MovieRead)
+async def update_movie(movie_id: int, movie_update: MovieUpdate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(MovieModel).where(MovieModel.id == movie_id).options(
+        selectinload(MovieModel.country),
+        selectinload(MovieModel.genres),
+        selectinload(MovieModel.actors),
+        selectinload(MovieModel.languages),
+    ))
+    movie = result.scalar_one_or_none()
+
+    if not movie:
+        raise HTTPException(status_code=404, detail="Movie with the given ID was not found.")
+
+    update_data = movie_update.model_dump(exclude_unset=True)
+
+    for key, value in update_data.items():
+        setattr(movie, key, value)
+
+    try:
+        await db.commit()
+        await db.refresh(movie)
+        return {"detail": "Movie updated successfully."}
+
+    except Exception as e:
+        print(f"Error occurred: {e}")
+        await db.rollback()
+        raise HTTPException(status_code=400, detail="Invalid input data.")
+
+
+@router.delete("/movies/{movie_id}/")
+async def delete_movie(movie_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(MovieModel).where(MovieModel.id == movie_id))
+    movie = result.scalars().first()
+    if not movie:
+        raise HTTPException(status_code=404, detail="Movie with the given ID was not found.")
+    await db.delete(movie)
+    await db.commit()
+    return Response(status_code=204)

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,5 +1,5 @@
-from schemas.movies import (
-    MovieDetailSchema,
-    MovieListResponseSchema,
-    MovieListItemSchema
-)
+# from schemas.movies import (
+#     MovieDetailSchema,
+#     MovieListResponseSchema,
+#     MovieListItemSchema
+# )

--- a/src/schemas/movies.py
+++ b/src/schemas/movies.py
@@ -1,1 +1,137 @@
-# Write your code here
+from datetime import datetime
+from pydantic import BaseModel, Field, field_validator
+from datetime import date, timedelta
+from typing import List, Optional
+
+
+class CountrySchema(BaseModel):
+    id: int
+    code: str
+    name: Optional[str] = None
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class GenreSchema(BaseModel):
+    id: int
+    name: Optional[str] = None
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class ActorSchema(BaseModel):
+    id: int
+    name: str
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class LanguageSchema(BaseModel):
+    id: int
+    name: str
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class MovieBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    date: date
+    score: float = Field(..., ge=0, le=100)
+    overview: str
+    status: str
+    budget: float = Field(..., ge=0)
+    revenue: float = Field(..., ge=0)
+    country: CountrySchema
+    genres: List[GenreSchema]
+    actors: List[ActorSchema]
+    languages: List[LanguageSchema]
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class MovieCreate(BaseModel):
+    name: str = Field(..., max_length=255)
+    date: date
+    score: float = Field(..., ge=0, le=100)
+    overview: str
+    status: str
+    budget: float = Field(..., ge=0)
+    revenue: float = Field(..., ge=0)
+    country: str
+    genres: List[str]
+    actors: List[str]
+    languages: List[str]
+    model_config = {
+        "from_attributes": True
+    }
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def validate_date(cls, value: Optional[date]):
+        if isinstance(value, str):
+            try:
+                value = datetime.strptime(value, "%Y-%m-%d").date()
+            except ValueError:
+                raise ValueError("Invalid date format. Expected YYYY-MM-DD.")
+        if value and value > date.today() + timedelta(days=365):
+            raise ValueError("Date must not be more than one year in the future.")
+        return value
+
+
+class MovieUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    date: Optional[date] = None
+    score: Optional[float] = Field(None, ge=0, le=100)
+    overview: Optional[str] = None
+    status: Optional[str] = None
+    budget: Optional[float] = Field(None, ge=0)
+    revenue: Optional[float] = Field(None, ge=0)
+
+    model_config = {
+        "from_attributes": True
+    }
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def validate_date(cls, value: Optional[date]):
+        if value and value > date.today() + timedelta(days=365):
+            raise ValueError("Date must not be more than one year in the future.")
+        return value
+
+
+class MovieRead(MovieBase):
+    id: int
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class MovieShortSchema(BaseModel):
+    id: int
+    name: str
+    date: date
+    score: float
+    overview: str
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class PaginatedMoviesResponse(BaseModel):
+    movies: List[MovieShortSchema]
+    prev_page: Optional[str]
+    next_page: Optional[str]
+    total_pages: int
+    total_items: int
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class MoviesListResponse(BaseModel):
+    movies: List[MovieShortSchema]


### PR DESCRIPTION
This PR adds full CRUD functionality for the `Movie` model including:
- GET `/movies/` with pagination and related models
- GET `/movies/{id}` with full nested response
- POST `/movies/` with auto-creation of related `country`, `genres`, `actors`, and `languages`
- PATCH `/movies/{id}` with validation and partial update
- DELETE `/movies/{id}`

Also includes:
- Schema adjustments for nested serialization
- Validation for future dates
- Test data support